### PR TITLE
DOS: nearptr and SVGA enhancements.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -11,6 +11,12 @@ GIT - MZX 2.93e
 
 USERS
 
++ DOS: fixed crashes when starting with the SVGA renderer
+  selected and a Sound Blaster present.
++ DOS: SVGA renderer should now correctly detect when a card
+  doesn't have enough memory to page flip.
++ DOS: fixed nearptr optimizations for Sound Blaster DMA under
+  CWSDPMI, PMODE/DJ, 386MAX/DPMIONE, possibly other DPMI hosts.
 + DOS: fixed 16-bit DMA for the Sound Blaster 16.
 + NDS: fixed PC speaker playback of rests (e.g. game over SFX).
 + Unix/Darwin: installed utilities are now prefixed with

--- a/src/audio/djgpp/audio_sb.c
+++ b/src/audio/djgpp/audio_sb.c
@@ -62,8 +62,9 @@ struct sb_config
   struct irq_state old_irq_state;
   _go32_dpmi_seginfo old_irq_handler;
   // - if nearptr enabled
-  boolean nearptr_buffer_enabled;
-  __dpmi_meminfo nearptr_buffer_mapping;
+  boolean nearptr_enabled;
+  __dpmi_meminfo nearptr_mapping;
+  int nearptr_type;
 };
 
 static struct sb_config sb_cfg;
@@ -73,7 +74,7 @@ static void audio_sb_clear_buffer(void)
   int zero = (sb_cfg.buffer_format == SAMPLE_U8) ? 0x80 : 0;
   memset(sb_cfg.buffer, zero, sb_cfg.buffer_size * BUFFER_BLOCKS);
 
-  if(!sb_cfg.nearptr_buffer_enabled)
+  if(!sb_cfg.nearptr_enabled)
   {
     dosmemput(sb_cfg.buffer, sb_cfg.buffer_size * BUFFER_BLOCKS,
      sb_cfg.buffer_segment << 4);
@@ -87,7 +88,7 @@ static void audio_sb_fill_block(void)
   audio_mixer_render_frames(sb_cfg.buffer + offset,
    sb_cfg.buffer_frames, sb_cfg.buffer_channels, sb_cfg.buffer_format);
 
-  if(!sb_cfg.nearptr_buffer_enabled)
+  if(!sb_cfg.nearptr_enabled)
   {
     dosmemput(sb_cfg.buffer + offset, sb_cfg.buffer_size,
      (sb_cfg.buffer_segment << 4) + offset);
@@ -265,8 +266,6 @@ static boolean init_audio_driver_sb(struct config_info *conf)
       rate = 1000000 / (sb_cfg.buffer_channels * (256 - time_constant));
     }
 
-    sb_cfg.nearptr_buffer_enabled = djgpp_push_enable_nearptr();
-
     if(!audio_mixer_init(rate, frames, sb_cfg.buffer_channels))
       goto err;
 
@@ -279,23 +278,12 @@ static boolean init_audio_driver_sb(struct config_info *conf)
     if(sb_cfg.buffer_segment < 0)
       goto err;
 
-    if(sb_cfg.nearptr_buffer_enabled)
-    {
-      sb_cfg.nearptr_buffer_mapping.address = sb_cfg.buffer_segment << 4;
-      sb_cfg.nearptr_buffer_mapping.size = sb_cfg.buffer_size;
-      if(__dpmi_physical_address_mapping(&sb_cfg.nearptr_buffer_mapping) != 0)
-      {
-        sb_cfg.nearptr_buffer_enabled = false;
-        djgpp_pop_enable_nearptr();
-      }
-      else
-      {
-        sb_cfg.buffer = (uint8_t *)(sb_cfg.nearptr_buffer_mapping.address +
-         __djgpp_conventional_base);
-      }
-    }
+    sb_cfg.buffer = (uint8_t *)djgpp_map_physical_memory(
+     sb_cfg.buffer_segment << 4, sb_cfg.buffer_size,
+     &sb_cfg.nearptr_mapping, &sb_cfg.nearptr_type);
 
-    if(!sb_cfg.nearptr_buffer_enabled)
+    sb_cfg.nearptr_enabled = (sb_cfg.buffer != NULL);
+    if(!sb_cfg.nearptr_enabled)
     {
       sb_cfg.buffer = (uint8_t *)cmalloc(sb_cfg.buffer_size * BUFFER_BLOCKS);
       if(!sb_cfg.buffer)
@@ -420,15 +408,11 @@ static void quit_audio_driver_sb(void)
 
     djgpp_disable_dma(sb_cfg.active_dma);
 
-    if(sb_cfg.nearptr_buffer_enabled)
-    {
-      __dpmi_free_physical_address_mapping(&(sb_cfg.nearptr_buffer_mapping));
-      djgpp_pop_enable_nearptr();
-    }
+    if(sb_cfg.nearptr_enabled)
+      djgpp_unmap_physical_memory(&sb_cfg.nearptr_mapping, &sb_cfg.nearptr_type);
     else
-    {
       free(sb_cfg.buffer);
-    }
+
     __dpmi_free_dos_memory(sb_cfg.buffer_selector);
   }
 }

--- a/src/platform/djgpp/platform_djgpp.c
+++ b/src/platform/djgpp/platform_djgpp.c
@@ -21,6 +21,7 @@
 
 #define delay delay_dos
 #include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <pc.h>
 #include <dos.h>
@@ -38,22 +39,24 @@
 /* TODO: Most of the audio callback code can't currently be locked or moved
  * outside of the callback, which causes CWSDMPI to crash during paging.
  * Disable paging altogether for now.
+ *
+ * Non-moving sbrk() (default, specify anyway) is required for nearptr hacks.
  */
-int _crt0_startup_flags = _CRT0_FLAG_LOCK_MEMORY;
+int _crt0_startup_flags = _CRT0_FLAG_LOCK_MEMORY | _CRT0_FLAG_NONMOVE_SBRK;
 
 static int djgpp_nearptr_cnt = 0;
 
-boolean djgpp_push_enable_nearptr(void)
+static boolean djgpp_push_enable_nearptr(void)
 {
-  if(djgpp_nearptr_cnt > 0)
-    return true;
-  if(!__djgpp_nearptr_enable())
-    return false;
+  if(djgpp_nearptr_cnt == 0)
+    if(!__djgpp_nearptr_enable())
+      return false;
+
   djgpp_nearptr_cnt++;
   return true;
 }
 
-boolean djgpp_pop_enable_nearptr(void)
+static boolean djgpp_pop_enable_nearptr(void)
 {
   if(djgpp_nearptr_cnt <= 0)
     return false;
@@ -61,79 +64,6 @@ boolean djgpp_pop_enable_nearptr(void)
     __djgpp_nearptr_disable();
   djgpp_nearptr_cnt--;
   return true;
-}
-
-int djgpp_display_adapter_detect(void)
-{
-  __dpmi_regs reg;
-
-  // VESA SuperVGA BIOS (VBE) - GET SuperVGA INFORMATION
-  // Generally supported by SVGA cards
-  reg.x.ax = 0x4F00;
-  reg.x.di = __tb & 0xF;
-  reg.x.es = (__tb >> 4);
-  __dpmi_int(0x10, &reg);
-
-  if(reg.x.ax == 0x004F)
-  {
-    struct vbe_info vbe;
-    dosmemget(__tb, sizeof(struct vbe_info), &vbe);
-    if(memcmp(vbe.signature, "VESA", 4) == 0)
-    {
-      if(vbe.version >= 0x300)
-        return DISPLAY_ADAPTER_VBE30;
-      else
-
-      if(vbe.version >= 0x200)
-        return DISPLAY_ADAPTER_VBE20;
-
-      return DISPLAY_ADAPTER_SVGA;
-    }
-  }
-
-  // VIDEO - GET DISPLAY COMBINATION CODE (PS,VGA/MCGA)
-  // Generally supported by VGA cards
-  reg.x.ax = 0x1A00;
-  __dpmi_int(0x10, &reg);
-
-  if(reg.h.al == 0x1A)
-  {
-    switch(reg.h.bl) {
-      case 0x04:
-      case 0x05:
-        return DISPLAY_ADAPTER_EGA;
-      case 0x07:
-      case 0x08:
-        return DISPLAY_ADAPTER_VGA;
-      default:
-        return DISPLAY_ADAPTER_UNSUPPORTED;
-    }
-  }
-
-  // VIDEO - ALTERNATE FUNCTION SELECT (PS, EGA, VGA, MCGA) - GET EGA INFO
-  // Generally supported by EGA cards
-  reg.h.ah = 0x12;
-  reg.x.bx = 0xFF10;
-  __dpmi_int(0x10, &reg);
-
-  if(reg.h.bh != 0xFF)
-    return DISPLAY_ADAPTER_EGA;
-
-  return DISPLAY_ADAPTER_UNSUPPORTED;
-}
-
-const char *disp_adapter_names[] =
-{
-  "Unsupported",
-  "EGA",
-  "VGA",
-  "SVGA",
-  "SVGA (VBE 2.0+)"
-};
-
-const char *djgpp_display_adapter_name(int adapter)
-{
-  return disp_adapter_names[adapter];
 }
 
 /**
@@ -171,6 +101,115 @@ int djgpp_malloc_boundary(int len_bytes, int boundary_bytes, int *selector)
     segment = (segment + len_paragraphs) & boundary_mask;
 
   return segment;
+}
+
+/* Method 1: Physical Address Mapping 800h
+ *
+ * Some DPMI clients support directly mapping below 1MiB despite this being
+ * against the specification. CWSDPMI does not support this, but Windows does.
+ * This should always work for addresses over 1MiB, so try it first.
+ */
+static void *map_physical_memory_over_1mb(uint32_t address, size_t len_bytes,
+ __dpmi_meminfo *mi, int *type)
+{
+  mi->address = address;
+  mi->size = len_bytes;
+  if(__dpmi_physical_address_mapping(mi))
+    return NULL;
+
+  debug("--NEARPTR-- %08" PRIx32 "h %zd (physical mapping)\n", address, len_bytes);
+  *type = 1;
+  return (void *)(mi->address + __djgpp_conventional_base);
+}
+
+/* Method 2: Map Device Memory in Memory Block 508h
+ *           Map Conventional Memory in Memory Block 509h
+ *
+ * TODO: this method is non-trivial and has few benefits over methods 1 and 3,
+ * so it hasn't been implemented.
+ */
+//void *map_physical_memory_dpmi_10() {}
+
+/* Method 3: Manually derive nearptr offset.
+ *
+ * Don't bother with the physical address mapping, as
+ * "most DPMI servers map the first Megabyte 1:1 anyway"
+ * and nearptr permits access to the entire address space.
+ * This is confirmed to work with CWSDPMI, PMODE/DJ, and 386MAX/DPMIONE.
+ */
+static void *map_physical_memory_manual(uint32_t address, size_t len_bytes,
+ __dpmi_meminfo *mi, int *type)
+{
+  /* Only support first 1MiB of memory */
+  if(address >= 1024 * 1024 || address + len_bytes > 1024 * 1024)
+    return NULL;
+
+  debug("--NEARPTR-- %08" PRIx32 "h %zd (manual)\n", address, len_bytes);
+  *type = 3;
+  return (void *)(address + __djgpp_conventional_base);
+}
+
+/**
+ * Use to nearptr map an allocation in conventional or device memory e.g.
+ * allocated by djgpp_malloc_boundary or __dpmi_allocate_dos_memory.
+ *
+ * @param address     absolute address of the area to be mapped.
+ * @param len_bytes   length of the area to be mapped, in bytes.
+ * @param mi          __dpmi_meminfo required to unmap this buffer.
+ * @param type        the type of mapping is stored here to allow unmapping.
+ * @return            a pointer usable by the caller addressing the requested
+ *                    area of conventional memory on success, otherwise NULL.
+ */
+void *djgpp_map_physical_memory(uint32_t address, size_t len_bytes,
+ __dpmi_meminfo *mi, int *type)
+{
+  void *ret;
+
+  *type = 0;
+  if((uint64_t)address + len_bytes > UINT32_MAX)
+    return NULL;
+
+  if(!djgpp_push_enable_nearptr())
+    return NULL;
+
+  ret = map_physical_memory_over_1mb(address, len_bytes, mi, type);
+  if(ret)
+    return ret;
+
+  /*
+  ret = map_physical_memory_dpmi_10(address, len_bytes, mi, type);
+  if(ret)
+    return ret;
+  */
+
+  ret = map_physical_memory_manual(address, len_bytes, mi, type);
+  if(ret)
+    return ret;
+
+  djgpp_pop_enable_nearptr();
+  return NULL;
+}
+
+/**
+ * Unmap djgpp_map_physical_memory.
+ *
+ * @param mi          __dpmi_meminfo containing the original mapping info.
+ * @param type        type pointer that was provided to the original mapping.
+ */
+void djgpp_unmap_physical_memory(__dpmi_meminfo *mi, int *type)
+{
+  switch(*type)
+  {
+    case 1:
+      /* This is a DPMI 1.0 function but supported by CWSDPMI and PMODE/DJ */
+      __dpmi_free_physical_address_mapping(mi);
+      /* fall-through */
+
+    case 3:
+      djgpp_pop_enable_nearptr();
+      break;
+  }
+  *type = 0;
 }
 
 static void djgpp_enable_dma16(uint8_t port, uint8_t mode, int offset, int bytes)
@@ -333,9 +372,20 @@ boolean platform_init(void)
   __dpmi_meminfo region;
   __dpmi_paddr handler;
   unsigned long base;
+  int flags;
+  char vendor[128];
 
   // Disable exception on Ctrl-C
   __djgpp_set_ctrl_c(0);
+
+  // Print DPMI vendor and capabilities if supported
+  if(__dpmi_get_capabilities(&flags, vendor) == 0)
+  {
+    info("DPMI vendor: %s %d.%d (%02xh)\n",
+     vendor + 2, vendor[0], vendor[1], flags);
+  }
+  else
+    info("DPMI vendor: unknown\n");
 
   // Check if DPMI yield function is supported
   errno = 0;

--- a/src/platform/djgpp/platform_djgpp.h
+++ b/src/platform/djgpp/platform_djgpp.h
@@ -26,6 +26,7 @@
 MEGAZEUX_BEGIN_DECLS
 
 #include <stdint.h>
+#include <dpmi.h>
 
 #define DMA_BOUNDARY  0x10000 /* For djgpp_malloc_boundary */
 
@@ -33,76 +34,16 @@ MEGAZEUX_BEGIN_DECLS
 #define DMA_READ      0x44
 #define DMA_WRITE     0x48
 
-enum
-{
-  DISPLAY_ADAPTER_UNSUPPORTED,
-  DISPLAY_ADAPTER_EGA,
-  DISPLAY_ADAPTER_VGA,
-  DISPLAY_ADAPTER_SVGA,
-  DISPLAY_ADAPTER_VBE20,
-  DISPLAY_ADAPTER_VBE30
-};
-
-struct vbe_info
-{
-  char signature[4];
-  uint16_t version;
-  uint32_t oem_name;
-  uint32_t capabilities;
-  uint32_t modes;
-  uint16_t memory_size;
-  uint16_t oem_version;
-  uint32_t vendor_name;
-  uint32_t product_name;
-  uint32_t product_revision;
-} __attribute__((packed));
-
-struct vbe_mode_info
-{
-  uint16_t attr;
-  uint8_t window_a_attr;
-  uint8_t window_b_attr;
-  uint16_t window_granularity;
-  uint16_t window_size;
-  uint16_t window_a_start;
-  uint16_t window_b_start;
-  uint32_t window_positioning_func;
-  uint16_t pitch;
-  uint16_t width;
-  uint16_t height;
-  uint8_t char_width;
-  uint8_t char_height;
-  uint8_t memory_planes;
-  uint8_t bpp;
-  uint8_t memory_banks;
-  uint8_t memory_model_type;
-  uint8_t bank_size;
-  uint8_t image_pages;
-  uint8_t reserved1;
-  uint8_t red_mask_size;
-  uint8_t red_field_size;
-  uint8_t green_mask_size;
-  uint8_t green_field_size;
-  uint8_t blue_mask_size;
-  uint8_t blue_field_size;
-  uint16_t reserved2;
-  uint8_t direct_color_mode_info;
-  uint32_t linear_ptr;
-  uint32_t offscreen_ptr;
-  uint16_t offscreen_size;
-} __attribute__((packed));
-
 struct irq_state
 {
   int port_21h;
   int port_A1h;
 };
 
-int djgpp_display_adapter_detect(void);
-const char *djgpp_display_adapter_name(int adapter);
 int djgpp_malloc_boundary(int len_bytes, int boundary_bytes, int *selector);
-boolean djgpp_push_enable_nearptr(void);
-boolean djgpp_pop_enable_nearptr(void);
+void *djgpp_map_physical_memory(uint32_t address, size_t len_bytes,
+ __dpmi_meminfo *mi, int *type);
+void djgpp_unmap_physical_memory(__dpmi_meminfo *mi, int *type);
 void djgpp_enable_dma(uint8_t port, uint8_t mode, int offset, int bytes);
 void djgpp_disable_dma(uint8_t port);
 

--- a/src/render/djgpp/Makefile.in
+++ b/src/render/djgpp/Makefile.in
@@ -6,6 +6,7 @@ ifeq (${BUILD_DJGPP},1)
 
 render_djgpp_obj  := ${render_obj}/djgpp
 render_djgpp_objs += \
+  ${render_djgpp_obj}/render_djgpp.o \
   ${render_djgpp_obj}/renderer_ega.o \
 
 ifeq (${BUILD_DOS_SVGA},1)

--- a/src/render/djgpp/render_djgpp.c
+++ b/src/render/djgpp/render_djgpp.c
@@ -1,0 +1,168 @@
+/* MegaZeux
+ *
+ * Copyright (C) 1996 Alexis Janson
+ * Copyright (C) 2010 Alan Williams <mralert@gmail.com>
+ * Copyright (C) 2019 Adrian Siekierka <kontakt@asie.pl>
+ * Copyright (C) 2026 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <inttypes.h>
+#include <string.h>
+
+#include <dos.h>
+#include <dpmi.h>
+#include <go32.h>
+#include <sys/farptr.h>
+
+#include "render_djgpp.h"
+#include "../../platform/log.h"
+
+enum display_adapter_type djgpp_display_adapter_detect(void)
+{
+  __dpmi_regs reg;
+
+  // VESA SuperVGA BIOS (VBE) - GET SuperVGA INFORMATION
+  // Generally supported by SVGA cards
+  reg.x.ax = 0x4F00;
+  reg.x.di = __tb & 0xF;
+  reg.x.es = (__tb >> 4);
+  __dpmi_int(0x10, &reg);
+
+  if(reg.x.ax == 0x004F)
+  {
+    struct vbe_info vbe;
+    dosmemget(__tb, sizeof(struct vbe_info), &vbe);
+    if(memcmp(vbe.signature, "VESA", 4) == 0)
+    {
+      if(vbe.version >= 0x300)
+        return DISPLAY_ADAPTER_VBE30;
+      else
+
+      if(vbe.version >= 0x200)
+        return DISPLAY_ADAPTER_VBE20;
+
+      return DISPLAY_ADAPTER_SVGA;
+    }
+  }
+
+  // VIDEO - GET DISPLAY COMBINATION CODE (PS,VGA/MCGA)
+  // Generally supported by VGA cards
+  reg.x.ax = 0x1A00;
+  __dpmi_int(0x10, &reg);
+
+  if(reg.h.al == 0x1A)
+  {
+    switch(reg.h.bl) {
+      case 0x04:
+      case 0x05:
+        return DISPLAY_ADAPTER_EGA;
+      case 0x07:
+      case 0x08:
+        return DISPLAY_ADAPTER_VGA;
+      default:
+        return DISPLAY_ADAPTER_UNSUPPORTED;
+    }
+  }
+
+  // VIDEO - ALTERNATE FUNCTION SELECT (PS, EGA, VGA, MCGA) - GET EGA INFO
+  // Generally supported by EGA cards
+  reg.h.ah = 0x12;
+  reg.x.bx = 0xFF10;
+  __dpmi_int(0x10, &reg);
+
+  if(reg.h.bh != 0xFF)
+    return DISPLAY_ADAPTER_EGA;
+
+  return DISPLAY_ADAPTER_UNSUPPORTED;
+}
+
+const char *djgpp_display_adapter_name(enum display_adapter_type adapter)
+{
+  static const char *disp_adapter_names[] =
+  {
+    "Unsupported",
+    "EGA",
+    "VGA",
+    "SVGA",
+    "SVGA (VBE 2.0)",
+    "SVGA (VBE 3.0+)",
+  };
+
+  if((unsigned)adapter >= DISPLAY_ADAPTER_MAX)
+    return "Unknown";
+
+  return disp_adapter_names[adapter];
+}
+
+void djgpp_print_vbe_mode_info(const struct vbe_mode_info *vbe)
+{
+  (void)vbe; /* nop if debug prints are not enabled */
+  debug("VBE mode info:\n"
+    "VBE 1.0:\n"
+    "  ModeAttributes:      %04" PRIx16 "h\n"
+    "  WinAAttributes:      %02" PRIx8 "h\n"
+    "  WinBAttributes:      %02" PRIx8 "h\n"
+    "  WinGranularity:      %" PRIu16 "\n"
+    "  WinSize:             %" PRIu16 "\n"
+    "  WinASegment:         %04" PRIx16 "h\n"
+    "  WinBSegment:         %04" PRIx16 "h\n"
+    "  WinFuncPtr:          %08" PRIx32 "h\n"
+    "  BytesPerScanline:    %" PRIu16 "\n"
+    "VBE 1.2:\n"
+    "  XResolution (px):    %" PRIu16 "\n"
+    "  YResolution (px):    %" PRIu16 "\n"
+    "  XCharSize:           %" PRIu8 "\n"
+    "  YCharSize:           %" PRIu8 "\n"
+    "  NumberOfPlanes:      %" PRIu8 "\n"
+    "  BitsPerPixel:        %" PRIu8 "\n"
+    "  NumberOfBanks:       %" PRIu8 "\n"
+    "  MemoryModel:         %02" PRIx8 "h\n"
+    "  BankSize (KiB):      %" PRIu8 "\n"
+    "  NumberOfImagePages:  %" PRIu8 "\n"
+    "  Reserved:            %" PRIu8 "\n"
+    "Direct color:\n"
+    "  RedMaskSize:         %" PRIu8 "\n"
+    "  RedFieldPosition:    %" PRIu8 "\n"
+    "  GreenMaskSize:       %" PRIu8 "\n"
+    "  GreenFieldPosition:  %" PRIu8 "\n"
+    "  BlueMaskSize:        %" PRIu8 "\n"
+    "  BlueFieldPosition:   %" PRIu8 "\n"
+    "  RsvdMaskSize:        %" PRIu8 "\n"
+    "  RsvdFieldPosition:   %" PRIu8 "\n"
+    "  DirectColorModeInfo: %02" PRIx8 "h\n"
+    "VBE 2.0:\n"
+    "  PhysBasePtr:         %08" PRIx32 "h\n"
+    "  OffScreenMemOffset:  %08" PRIx32 "h\n"
+    "  OffScreenMemSize:    %" PRIu16 "\n",
+
+    vbe->attr, vbe->window_a_attr, vbe->window_b_attr, vbe->window_granularity,
+    vbe->window_size, vbe->window_a_start, vbe->window_b_start,
+    vbe->window_positioning_func, vbe->pitch,
+
+    vbe->width, vbe->height, vbe->char_width, vbe->char_height,
+    vbe->memory_planes, vbe->bpp, vbe->memory_banks, vbe->memory_model_type,
+    vbe->bank_size, vbe->image_pages, vbe->reserved1,
+
+    vbe->red_mask_size, vbe->red_field_position,
+    vbe->green_mask_size, vbe->green_field_position,
+    vbe->blue_mask_size, vbe->blue_field_position,
+    vbe->rsvd_mask_size, vbe->rsvd_field_position,
+    vbe->direct_color_mode_info,
+
+    vbe->linear_ptr, vbe->offscreen_ptr, vbe->offscreen_size
+  );
+}

--- a/src/render/djgpp/render_djgpp.h
+++ b/src/render/djgpp/render_djgpp.h
@@ -1,0 +1,98 @@
+/* MegaZeux
+ *
+ * Copyright (C) 2010 Alan Williams <mralert@gmail.com>
+ * Copyright (C) 2019 Adrian Siekierka <kontakt@asie.pl>
+ * Copyright (C) 2026 Alice Rowan <petrifiedrowan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef MEGAZEUX_RENDER_DJGPP_H
+#define MEGAZEUX_RENDER_DJGPP_H
+
+#include "../../compat.h"
+
+MEGAZEUX_BEGIN_DECLS
+
+#include <stdint.h>
+
+enum display_adapter_type
+{
+  DISPLAY_ADAPTER_UNSUPPORTED,
+  DISPLAY_ADAPTER_EGA,
+  DISPLAY_ADAPTER_VGA,
+  DISPLAY_ADAPTER_SVGA,
+  DISPLAY_ADAPTER_VBE20,
+  DISPLAY_ADAPTER_VBE30,
+  DISPLAY_ADAPTER_MAX
+};
+
+struct vbe_info
+{
+  char signature[4];
+  uint16_t version;
+  uint32_t oem_name;
+  uint32_t capabilities;
+  uint32_t modes;
+  uint16_t memory_size;
+  uint16_t oem_version;
+  uint32_t vendor_name;
+  uint32_t product_name;
+  uint32_t product_revision;
+} __attribute__((packed));
+
+struct vbe_mode_info
+{
+  uint16_t attr;
+  uint8_t window_a_attr;
+  uint8_t window_b_attr;
+  uint16_t window_granularity;
+  uint16_t window_size;
+  uint16_t window_a_start;
+  uint16_t window_b_start;
+  uint32_t window_positioning_func;
+  uint16_t pitch;
+  uint16_t width;
+  uint16_t height;
+  uint8_t char_width;
+  uint8_t char_height;
+  uint8_t memory_planes;
+  uint8_t bpp;
+  uint8_t memory_banks;
+  uint8_t memory_model_type;
+  uint8_t bank_size;
+  uint8_t image_pages;
+  uint8_t reserved1;
+  uint8_t red_mask_size;
+  uint8_t red_field_position;
+  uint8_t green_mask_size;
+  uint8_t green_field_position;
+  uint8_t blue_mask_size;
+  uint8_t blue_field_position;
+  uint8_t rsvd_mask_size;
+  uint8_t rsvd_field_position;
+  uint8_t direct_color_mode_info;
+  uint32_t linear_ptr;
+  uint32_t offscreen_ptr;
+  uint16_t offscreen_size;
+} __attribute__((packed));
+
+enum display_adapter_type djgpp_display_adapter_detect(void);
+const char *djgpp_display_adapter_name(enum display_adapter_type adapter);
+void djgpp_print_vbe_mode_info(const struct vbe_mode_info *vbe);
+
+MEGAZEUX_END_DECLS
+
+#endif /* MEGAZEUX_RENDER_DJGPP_H */

--- a/src/render/djgpp/renderer_ega.c
+++ b/src/render/djgpp/renderer_ega.c
@@ -29,6 +29,7 @@
 #include <sys/movedata.h>
 #undef delay
 
+#include "render_djgpp.h"
 #include "../render.h"
 #include "../renderers.h"
 

--- a/src/render/djgpp/renderer_svga.c
+++ b/src/render/djgpp/renderer_svga.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2007 Alistair John Strachan <alistair@devzero.co.uk>
  * Copyright (C) 2007 Alan Williams <mralert@gmail.com>
  * Copyright (C) 2018, 2019 Adrian Siekierka <kontakt@asie.pl>
+ * Copyright (C) 2026 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -27,6 +28,7 @@
 #include <go32.h>
 #undef delay
 
+#include "render_djgpp.h"
 #include "../render.h"
 #include "../render_layer.h"
 #include "../renderers.h"
@@ -37,9 +39,13 @@
 struct svga_render_data
 {
   __dpmi_meminfo mapping;
-  uint8_t *ptr, *ptr2;
-  uint16_t line, line2;
-  uint16_t mode, pitch;
+  int mapping_type;
+  uint8_t *ptr;
+  uint8_t *ptr2;
+  uint16_t line;
+  uint16_t line2;
+  uint16_t mode;
+  uint16_t pitch;
   uint8_t display;
   boolean page_flip_ok;
   int update_colors;
@@ -94,6 +100,7 @@ static boolean svga_init_video(struct graphics_data *graphics,
   struct vbe_mode_info vbe;
   int x_offset, y_offset;
   __dpmi_regs reg;
+  uint32_t size;
 
   memset(&render_data, 0, sizeof(struct svga_render_data));
   graphics->render_data = &render_data;
@@ -102,9 +109,6 @@ static boolean svga_init_video(struct graphics_data *graphics,
   graphics->bits_per_pixel = conf->force_bpp;
   if(graphics->bits_per_pixel != 8 && graphics->bits_per_pixel != 16)
     graphics->bits_per_pixel = 16;
-
-  if(!djgpp_push_enable_nearptr())
-    return false;
 
   render_data.display = djgpp_display_adapter_detect();
   if(render_data.display < DISPLAY_ADAPTER_VBE20)
@@ -132,15 +136,21 @@ static boolean svga_init_video(struct graphics_data *graphics,
   }
 
   dosmemget(__tb, sizeof(struct vbe_mode_info), &vbe);
-  render_data.mapping.address = vbe.linear_ptr;
-  render_data.mapping.size = (graphics->resolution_height * vbe.pitch);
-  // TODO: detect if we have enough memory
-  render_data.page_flip_ok = true;
+  djgpp_print_vbe_mode_info(&vbe);
+
+  /* VBE image pages field indicates the total number, minus 1, of complete
+   * frames that will fit into video memory. If it's >=1, at least 2 images
+   * will fit and double buffering can be enabled. */
+  if(vbe.image_pages >= 1)
+    render_data.page_flip_ok = true;
+
+  size = graphics->resolution_height * vbe.pitch;
   if(render_data.page_flip_ok)
-    render_data.mapping.size <<= 1;
-  // round up to 4KB
-  render_data.mapping.size = (render_data.mapping.size + 4095) & (~4095);
-  if(__dpmi_physical_address_mapping(&render_data.mapping) != 0)
+    size <<= 1;
+
+  render_data.ptr = (uint8_t *)djgpp_map_physical_memory(
+   vbe.linear_ptr, size, &render_data.mapping, &render_data.mapping_type);
+  if(!render_data.ptr)
   {
     // set text video mode, leave
     reg.x.ax = 0x0010;
@@ -149,12 +159,12 @@ static boolean svga_init_video(struct graphics_data *graphics,
      render_data.mapping.size, render_data.mapping.address, render_data.mode);
     return false;
   }
+  memset(render_data.ptr, 0, size);
 
-  x_offset = (graphics->resolution_width - 640) / 2;
-  y_offset = (graphics->resolution_height - 350) / 2;
+  x_offset = (graphics->resolution_width - SCREEN_PIX_W) / 2;
+  y_offset = (graphics->resolution_height - SCREEN_PIX_H) / 2;
 
-  render_data.ptr = (uint8_t *)(render_data.mapping.address + __djgpp_conventional_base) +
-   (vbe.pitch * y_offset) + ((vbe.bpp >> 3) * x_offset);
+  render_data.ptr += (vbe.pitch * y_offset) + ((vbe.bpp >> 3) * x_offset);
 
   render_data.pitch = vbe.pitch;
   if(render_data.page_flip_ok)
@@ -164,16 +174,14 @@ static boolean svga_init_video(struct graphics_data *graphics,
     render_data.line2 = graphics->resolution_height;
   }
 
-  memset((uint8_t *)(render_data.mapping.address + __djgpp_conventional_base), 0,
-   vbe.pitch * vbe.height * (render_data.page_flip_ok ? 2 : 1));
   return true;
 }
 
 static void svga_free_video(struct graphics_data *graphics)
 {
   struct svga_render_data *render_data = graphics->render_data;
-  __dpmi_free_physical_address_mapping(&(render_data->mapping));
-  djgpp_pop_enable_nearptr();
+  djgpp_unmap_physical_memory(&render_data->mapping, &render_data->mapping_type);
+  /* FIXME: reset mode too like the EGA renderer */
 }
 
 static boolean svga_create_window(struct graphics_data *graphics,


### PR DESCRIPTION
* Convenience functions for mapping/unmapping physical memory (instead of every instance of this doing it mostly manually). This should fix all instances of nearptr being enabled but not disabled.
* Allow nearptr in conventional memory by manually calculating the memory offset, as DJGPP docs claim that the first 1MiB is usually mapped 1:1. This works with CWSDPMI, PMODE/DJ, and 386MAX, fixing nearptr optimizations for the Sound Blaster driver with these hosts. (Windows DPMI allows physically mapping conventional memory, but has broken Sound Blaster support; DR DOS 7.x is inconclusive.)
* Fix nearptr enablement counter, which caused crashes when initializing both the SVGA renderer and the Sound Blaster driver at startup if the Sound Blaster driver then failed nearptr setup.
* Split video functions from platform_djgpp.c to render_djgpp.c
* Check the number of image pages supported by the SVGA video mode before enabling page flipping.
* Add DPMI vendor startup message and VBE 2.0 mode debug output.